### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-x.metakgp.org


### PR DESCRIPTION
Temporarily remove the redirect to x.metakgp.org
