### PR TITLE
[BUG-FIX] "Recent Searches" list doesn't work because of changed result list structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,7 @@ root = true
 [*.rb]
 indent_style = space
 indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/client.js
+++ b/client.js
@@ -17,11 +17,9 @@ var addItem = function(item) {
     localStorage.setItem('searched', ',' + item + ',');
   }
 
-  $("ul.local-storage-list div > a:contains('" + item + "')").each(function() {
+  $("ul.local-storage-list > li > a:contains('" + item + "')").each(function() {
     if ($(this).text() === item) {
-      $(this)
-        .parent()
-        .remove();
+      $(this).parent().remove();
     }
   });
   $('ul.local-storage-list').prepend(
@@ -45,21 +43,6 @@ $(function() {
     });
     $('ul.local-storage-list').append('<br/><br/>');
   }
-
-  $(document).click(function(e) {
-    if (DEBUG) console.log('Clicked somewhere in the doc');
-    // figure out if this is a result click
-    if (e.target.classList.contains('result-link')) {
-      // this is a result link
-      var query_value = $('#query')
-        .val()
-        .trim();
-      addItem(query_value);
-      $('div.local-storage-div').show();
-      if (DEBUG)
-        console.log('Local storage: ' + localStorage.getItem('searched'));
-    }
-  });
 
   var worker = new Worker('resources/scripts/worker2.js');
   $.getJSON('data/data.json')
@@ -111,16 +94,20 @@ $(function() {
         '</h1></a><li>';
     }
     $('.result-list').html(html);
-    $('.result-link').click(function() {
-      ga(
-        'send',
-        'event',
-        'Result',
-        'click',
-        $('#query')
-          .val()
-          .trim()
-      );
+    /**
+     * Bind a handler to a click on the result link to save the search in local storage
+     *
+     * Sample result HTML:
+     * <a class="result-link">
+     *    <div> ... </div>
+     *    <h1> ... </h1>
+     * </a>
+     */
+    $("a.result-link").click(function(e) {
+      var query = $('#query').val().trim();
+      addItem(query);
+      $('div.local-storage-div').show();
+      ga('send', 'event', 'Result', 'click', query);
     });
   }
 

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ fjs.parentNode.insertBefore(js, fjs);
                 </div>
             </div>
 
-            <div class="local-storage-div sidebar">
+            <div class="sidebar">
 
                 <h1>MFQP</h1>
                 <p>Made with &lt;/&gt; and &hearts;</p>
@@ -71,9 +71,11 @@ fjs.parentNode.insertBefore(js, fjs);
                     <a href="mailto:metakgp-qp@googlegroups.com">metakgp-qp@googlegroups.com</a>
                 </p>
 
+                <div class="local-storage-div">
                     <h2>Your Recent Searches</h2>
                     <ul class="local-storage-list">
                     </ul>
+                </div>
             </div>
         </div>
     </body>


### PR DESCRIPTION
## Bug

1. Clicking on a result link doesn't add the current search term to the recent searches link
1. Even if new searches are added, old searches are not removed properly leading to duplicates in the Recent Searches list (even though there are none in Local Storage)

## Trigger

#52 made a lot of changes to the UI and the JS code.

1. Recent searches not working
    1. Document click handler added the search to the recent searches list
    1. This handler was checking to see if the clicked element had the class `result-link`
    1. The result list structure was changed from `a.result-link` to `a.result-link > div h1`
    1. In the new structure, every click's target would be one of the children: `div` or `h1`, and neither of them have the `result-link` class, so the click handler would not consider the clicked element as a result link and won't add the search term to the recent searches list
1. Duplicate searches not removed from the Recent searches list
    1. Once bug 1 is fixed, this bug shows up. This was also introduced by the same PR
    1. When a new search term is clicked, the current logic performs the following steps:
        1. Replace current term it in the old stored string
        1. Add current term to the old string
        1. Store the string in `localStorage`
        1. Remove the elements matching the current term from the currently displayed Recent Searches list => BUG
        1. Prepend the current search term to the recent searches list (thus bringing to the top)
    1. In step 4 above, the removal relies on the structure of the Recent Searches list.
        1. Before: `ul.local-storage-list div > a`
        1. After: `ul.local-storage-list > li > a`

## Impact

- Recent searches were not stored for users since Oct 19, 2019

## Fix

1. Attach the handler to `a.result-link` => This ensures that the handler is triggered whenever the `a` or one of it's children are clicked
1. Fix the element pattern for removing duplicates from the recent searches page

I have tested this locally in a bunch of scenarios and it works as expected. :+1:  

Fix #54 

## Other changes in this PR

- #52 also converted several function calls to write the arguments one line each. This is especially confusing when the full search call can be accomodated on a single line. I changed some fuctions. I will run `semistandard --lint` on the JS file in a later PR.