### PR TITLE
Revert "remove .editorconfig from git file tree"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.rb]
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea/
 .vscode/
-.editorconfig


### PR DESCRIPTION
This reverts commit 7b34f37c64865747cbf38195c6ef4c9c0f292698.

As per discussion in Slack, it is important to have the file to ensure that indentation is uniform throughout the project.